### PR TITLE
rebase hls4ml

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -11,7 +11,7 @@ dependencies:
     - jupyter
     - tensorflow==2.5
     - tensorflow_datasets
-    - git+https://github.com/jmduarte/hls4ml.git@split_pointwise_conv_by_rf#egg=hls4ml[profiling]
+    - git+https://github.com/jmduarte/hls4ml.git@split_pointwise_conv_by_rf_rebase#egg=hls4ml[profiling]
     - git+https://github.com/google/qkeras.git#egg=qkeras
     - scikit-learn
     - uproot

--- a/synthesize.py
+++ b/synthesize.py
@@ -27,7 +27,7 @@ import argparse
 
 import os
 
-def synthezise(mname,datapath,plotpath,ONAME,build=False,trace=False):
+def synthesize(mname,datapath,plotpath,ONAME,build=False,trace=False):
 
   nfeat = 3
 
@@ -89,6 +89,8 @@ def synthezise(mname,datapath,plotpath,ONAME,build=False,trace=False):
         # conv1D_e2 may not exist
         config["LayerName"]["conv1D_e2"]["ReuseFactor"] = nconst  # divisors of nconst*(nconst-1)
         #print ("conv1D_e2 exists")
+      if 'Conv1D' in layer.__class__.__name__:
+        config["LayerName"][layer.name]["ConvImplementation"] = "Pointwise"
         
 
     config["LayerName"]["concatenate"] = {}
@@ -319,7 +321,7 @@ if __name__ == "__main__":
   # Generate projects and produce firmware  
   if args.create or args.build:  
     start = time.time()
-    Parallel(n_jobs=4, backend='multiprocessing')(delayed(synthezise)(modelname,DATA,PLOTS,ONAME,build=args.build) for modelname in models)
+    Parallel(n_jobs=4, backend='multiprocessing')(delayed(synthesize)(modelname,DATA,PLOTS,ONAME,build=args.build) for modelname in models)
     end = time.time()
     print('Ended after {:.4f} s'.format(end-start))
       

--- a/synthesize_sparse.py
+++ b/synthesize_sparse.py
@@ -27,7 +27,7 @@ import argparse
 
 import os
 
-def synthezise(mname,datapath,plotpath,ONAME,build=False,trace=False):
+def synthesize(mname,datapath,plotpath,ONAME,build=False,trace=False):
 
   nfeat = 3
 
@@ -89,6 +89,8 @@ def synthezise(mname,datapath,plotpath,ONAME,build=False,trace=False):
         # conv1D_e2 may not exist
         config["LayerName"]["conv1D_e2"]["ReuseFactor"] = nconst  # divisors of nconst*(nconst-1)
         #print ("conv1D_e2 exists")
+      if 'Conv1D' in layer.__class__.__name__:
+        config["LayerName"][layer.name]["ConvImplementation"] = "Pointwise"
         
 
     config["LayerName"]["concatenate"] = {}
@@ -325,7 +327,7 @@ if __name__ == "__main__":
   # Generate projects and produce firmware  
   if args.create or args.build:  
     start = time.time()
-    Parallel(n_jobs=4, backend='multiprocessing')(delayed(synthezise)(modelname,DATA,PLOTS,ONAME,build=args.build) for modelname in models)
+    Parallel(n_jobs=4, backend='multiprocessing')(delayed(synthesize)(modelname,DATA,PLOTS,ONAME,build=args.build) for modelname in models)
     end = time.time()
     print('Ended after {:.4f} s'.format(end-start))
       


### PR DESCRIPTION
- rebased hls4ml to lastest main + my pointwise conv1d implementation; see diff here: https://github.com/fastmachinelearning/hls4ml/compare/main...jmduarte:hls4ml:split_pointwise_conv_by_rf_rebase
- `config["LayerName"][layer.name]["ConvImplementation"] = "Pointwise"` switches to my unrolled pointwise conv1d implementation
- otherwise, it uses the default unrolled conv1d implementation in `main`
- this way we can test/compare both more easily in a single `hls4ml` version
@sznajder @walkieq @vloncar